### PR TITLE
feat: Replace slider with text field for testbed settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -31,7 +32,7 @@ configure(listOf(
     apply(plugin = "java")
     apply(plugin = "org.jetbrains.kotlin.jvm")
 
-    java {
+    extensions.configure<JavaPluginExtension> {
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(17))
         }

--- a/kfizzix-testbed-javafx/src/main/kotlin/com/hereliesaz/kbox2d/testbed/framework/javafx/TestbedSidePanel.kt
+++ b/kfizzix-testbed-javafx/src/main/kotlin/com/hereliesaz/kbox2d/testbed/framework/javafx/TestbedSidePanel.kt
@@ -163,15 +163,41 @@ class TestbedSidePanel(val model: TestbedModel, val controller: AbstractTestbedC
             }
             when (setting.constraintType) {
                 TestbedSetting.ConstraintType.RANGE -> {
-                    val text = Label(setting.name + ": " + setting.value)
-                    val slider = Slider(setting.min.toDouble(), setting.max.toDouble(), setting.value.toDouble())
-                    // slider.setMaximumSize(new Dimension(200, 20));
-                    slider.valueProperty().addListener { _, _, _ -> stateChanged(slider) }
-                    putClientProperty(slider, "name", setting.name)
-                    putClientProperty(slider, SETTING_TAG, setting)
-                    putClientProperty(slider, LABEL_TAG, text)
-                    argPanel.children.add(text)
-                    argPanel.children.add(slider)
+                    val hBox = HBox()
+                    hBox.alignment = Pos.CENTER_LEFT
+                    hBox.spacing = 5.0
+                    val label = Label(setting.name)
+                    val textField = TextField(setting.value.toString())
+                    textField.prefWidth = 50.0
+
+                    val updateSetting = {
+                        try {
+                            var value = textField.text.toInt()
+                            if (value < setting.min) value = setting.min
+                            if (value > setting.max) value = setting.max
+                            setting.value = value
+                            textField.text = value.toString()
+                        } catch (e: NumberFormatException) {
+                            textField.text = setting.value.toString()
+                        }
+                    }
+
+                    // Action on Enter key press
+                    textField.setOnAction {
+                        updateSetting()
+                        model.panel.grabFocus()
+                    }
+
+                    // Action on focus lost (blur)
+                    textField.focusedProperty().addListener { _, _, newValue ->
+                        if (!newValue) { // Lost focus
+                            updateSetting()
+                            model.panel.grabFocus()
+                        }
+                    }
+
+                    hBox.children.addAll(label, textField)
+                    argPanel.children.add(hBox)
                 }
                 TestbedSetting.ConstraintType.BOOLEAN -> {
                     val checkbox = CheckBox(setting.name)


### PR DESCRIPTION
Replaces the Slider control with a TextField for editing numerical settings in the JavaFX testbed side panel.

This allows users to manually type in precise values for settings like 'Iterations' or 'Gravity'.

The new text field updates the setting value on two conditions:
- When the 'Enter' key is pressed.
- When the input field loses focus (on blur).

This change is based on a user request to have changes saved on blur, which implied a text-based input was desired over the existing slider.

## Summary by Sourcery

Replace slider controls in the JavaFX testbed side panel with text fields for numeric settings that validate and update values on Enter key press or focus loss, and streamline the Gradle Java toolchain configuration.

New Features:
- Replace slider controls with text fields for range-constrained testbed settings

Enhancements:
- Validate and clamp text input, updating the setting on Enter or when the field loses focus
- Wrap setting label and text field in an HBox for consistent alignment and spacing

Build:
- Configure the Java toolchain using extensions.configure<JavaPluginExtension> in build.gradle.kts