### PR TITLE
Fix compilation warnings in ParticleSystem and VoronoiDiagram

### DIFF
--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
@@ -1666,7 +1666,10 @@ class ParticleSystem(var world: World) {
      * Callback used with VoronoiDiagram.
      */
     class CreateParticleGroupCallback : VoronoiDiagramCallback {
-        override fun callback(a: Int, b: Int, c: Int) {
+        override fun callback(aTag: Int, bTag: Int, cTag: Int) {
+            val a = aTag
+            val b = bTag
+            val c = cTag
             val pa = system!!.positionBuffer.data!![a]!!
             val pb = system!!.positionBuffer.data!![b]!!
             val pc = system!!.positionBuffer.data!![c]!!
@@ -1718,7 +1721,10 @@ class ParticleSystem(var world: World) {
 
     // Callback used with VoronoiDiagram.
     class JoinParticleGroupsCallback : VoronoiDiagramCallback {
-        override fun callback(a: Int, b: Int, c: Int) {
+        override fun callback(aTag: Int, bTag: Int, cTag: Int) {
+            val a = aTag
+            val b = bTag
+            val c = cTag
             // Create a triad if it will contain particles from both groups.
             val countA = ((if (a < groupB!!.firstIndex) 1 else 0)
                     + (if (b < groupB!!.firstIndex) 1 else 0)
@@ -2033,17 +2039,17 @@ class ParticleSystem(var world: World) {
 
         private fun lowerBound(ray: Array<Proxy?>?, length: Int, tag: Long): Int {
             var left = 0
-            var length = length
+            var len = length
             var step: Int
             var curr: Int
-            while (length > 0) {
-                step = length / 2
+            while (len > 0) {
+                step = len / 2
                 curr = left + step
                 if (ray!![curr]!!.tag < tag) {
                     left = curr + 1
-                    length -= step + 1
+                    len -= step + 1
                 } else {
-                    length = step
+                    len = step
                 }
             }
             return left
@@ -2051,17 +2057,17 @@ class ParticleSystem(var world: World) {
 
         private fun upperBound(ray: Array<Proxy?>?, length: Int, tag: Long): Int {
             var left = 0
-            var length = length
+            var len = length
             var step: Int
             var curr: Int
-            while (length > 0) {
-                step = length / 2
+            while (len > 0) {
+                step = len / 2
                 curr = left + step
                 if (ray!![curr]!!.tag <= tag) {
                     left = curr + 1
-                    length -= step + 1
+                    len -= step + 1
                 } else {
-                    length = step
+                    len = step
                 }
             }
             return left
@@ -2137,13 +2143,8 @@ class ParticleSystem(var world: World) {
         }
     }
 
-    fun raycast(callback: ParticleRaycastCallback, point1: Vec2, point2: Vec2) {
+    fun raycast(@Suppress("UNUSED_PARAMETER") callback: ParticleRaycastCallback, @Suppress("UNUSED_PARAMETER") point1: Vec2, @Suppress("UNUSED_PARAMETER") point2: Vec2) {
         // Simple check
-        val p = tempVec
-        for (i in 0 until count) {
-            val pos = positionBuffer.data!![i]!!
-            // Check distance to segment?
-            // Stub: do nothing or iterate all
-        }
+        // TODO: Implement raycast
     }
 }

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/VoronoiDiagram.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/VoronoiDiagram.kt
@@ -179,7 +179,7 @@ class VoronoiDiagram(generatorCapacity: Int) {
                 0,
                 MathUtils.min(g.center.y.toInt(), countY - 1)
             )
-            queue.push(taskPool.pop()!!.set(x, y, x + y * countX, g))
+            queue.push(taskPool.pop().set(x, y, x + y * countX, g))
         }
         while (!queue.empty()) {
             val front = queue.pop()
@@ -190,16 +190,16 @@ class VoronoiDiagram(generatorCapacity: Int) {
             if (diagram!![i] == null) {
                 diagram!![i] = g
                 if (x > 0) {
-                    queue.push(taskPool.pop()!!.set(x - 1, y, i - 1, g))
+                    queue.push(taskPool.pop().set(x - 1, y, i - 1, g))
                 }
                 if (y > 0) {
-                    queue.push(taskPool.pop()!!.set(x, y - 1, i - countX, g))
+                    queue.push(taskPool.pop().set(x, y - 1, i - countX, g))
                 }
                 if (x < countX - 1) {
-                    queue.push(taskPool.pop()!!.set(x + 1, y, i + 1, g))
+                    queue.push(taskPool.pop().set(x + 1, y, i + 1, g))
                 }
                 if (y < countY - 1) {
-                    queue.push(taskPool.pop()!!.set(x, y + 1, i + countX, g))
+                    queue.push(taskPool.pop().set(x, y + 1, i + countX, g))
                 }
             }
             taskPool.push(front)
@@ -212,8 +212,8 @@ class VoronoiDiagram(generatorCapacity: Int) {
                     val a = diagram!![i]
                     val b = diagram!![i + 1]
                     if (a !== b) {
-                        queue.push(taskPool.pop()!!.set(x, y, i, b))
-                        queue.push(taskPool.pop()!!.set(x + 1, y, i + 1, a))
+                        queue.push(taskPool.pop().set(x, y, i, b))
+                        queue.push(taskPool.pop().set(x + 1, y, i + 1, a))
                     }
                 }
             }
@@ -223,8 +223,8 @@ class VoronoiDiagram(generatorCapacity: Int) {
                     val a = diagram!![i]
                     val b = diagram!![i + countX]
                     if (a !== b) {
-                        queue.push(taskPool.pop()!!.set(x, y, i, b))
-                        queue.push(taskPool.pop()!!.set(x, y + 1, i + countX, a))
+                        queue.push(taskPool.pop().set(x, y, i, b))
+                        queue.push(taskPool.pop().set(x, y + 1, i + countX, a))
                     }
                 }
             }
@@ -246,16 +246,16 @@ class VoronoiDiagram(generatorCapacity: Int) {
                     if (a2 > b2) {
                         diagram!![i] = k
                         if (x > 0) {
-                            queue.push(taskPool.pop()!!.set(x - 1, y, i - 1, k))
+                            queue.push(taskPool.pop().set(x - 1, y, i - 1, k))
                         }
                         if (y > 0) {
-                            queue.push(taskPool.pop()!!.set(x, y - 1, i - countX, k))
+                            queue.push(taskPool.pop().set(x, y - 1, i - countX, k))
                         }
                         if (x < countX - 1) {
-                            queue.push(taskPool.pop()!!.set(x + 1, y, i + 1, k))
+                            queue.push(taskPool.pop().set(x + 1, y, i + 1, k))
                         }
                         if (y < countY - 1) {
-                            queue.push(taskPool.pop()!!.set(x, y + 1, i + countX, k))
+                            queue.push(taskPool.pop().set(x, y + 1, i + countX, k))
                         }
                         updated = true
                     }


### PR DESCRIPTION
- Renamed parameters in `VoronoiDiagramCallback` implementations (`CreateParticleGroupCallback`, `JoinParticleGroupsCallback`) to `aTag`, `bTag`, `cTag` to match the interface and resolve shadowing.
- Renamed local variable `length` to `len` in `ParticleSystem.lowerBound` and `ParticleSystem.upperBound` to avoid parameter shadowing.
- Updated `ParticleSystem.raycast` stub to suppress unused parameter warnings and added a TODO for future implementation.
- Removed redundant non-null assertions (`!!`) in `VoronoiDiagram.kt` where `taskPool.pop()` returns a non-nullable type.
- Retained necessary non-null assertions in `ParticleSystem.kt` for buffer rotations to satisfy `BufferUtils.rotate` type requirements.

---
*PR created automatically by Jules for task [8417965262888439037](https://jules.google.com/task/8417965262888439037) started by @HereLiesAz*