### PR TITLE
Fix Kotlin compiler warnings and API inconsistencies

### DIFF
--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/pooling/normal/DefaultWorldPool.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/pooling/normal/DefaultWorldPool.kt
@@ -70,6 +70,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return PolygonContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -79,6 +80,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return CircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -88,6 +90,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return PolygonAndCircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -97,6 +100,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return EdgeAndCircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -106,6 +110,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return EdgeAndPolygonContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -115,6 +120,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return ChainAndCircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -124,6 +130,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return ChainAndPolygonContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -203,56 +210,56 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
         return vecs.pop()
     }
 
-    override fun popVec2(argNum: Int): Array<Vec2> {
-        return vecs.pop(argNum)
+    override fun popVec2(num: Int): Array<Vec2> {
+        return vecs.pop(num)
     }
 
-    override fun pushVec2(argNum: Int) {
-        vecs.push(argNum)
+    override fun pushVec2(num: Int) {
+        vecs.push(num)
     }
 
     override fun popVec3(): Vec3 {
         return vec3s.pop()
     }
 
-    override fun popVec3(argNum: Int): Array<Vec3> {
-        return vec3s.pop(argNum)
+    override fun popVec3(num: Int): Array<Vec3> {
+        return vec3s.pop(num)
     }
 
-    override fun pushVec3(argNum: Int) {
-        vec3s.push(argNum)
+    override fun pushVec3(num: Int) {
+        vec3s.push(num)
     }
 
     override fun popMat22(): Mat22 {
         return mats.pop()
     }
 
-    override fun popMat22(argNum: Int): Array<Mat22> {
-        return mats.pop(argNum)
+    override fun popMat22(num: Int): Array<Mat22> {
+        return mats.pop(num)
     }
 
-    override fun pushMat22(argNum: Int) {
-        mats.push(argNum)
+    override fun pushMat22(num: Int) {
+        mats.push(num)
     }
 
     override fun popMat33(): Mat33 {
         return mat33s.pop()
     }
 
-    override fun pushMat33(argNum: Int) {
-        mat33s.push(argNum)
+    override fun pushMat33(num: Int) {
+        mat33s.push(num)
     }
 
     override fun popAABB(): AABB {
         return aabbs.pop()
     }
 
-    override fun popAABB(argNum: Int): Array<AABB> {
-        return aabbs.pop(argNum)
+    override fun popAABB(num: Int): Array<AABB> {
+        return aabbs.pop(num)
     }
 
-    override fun pushAABB(argNum: Int) {
-        aabbs.push(argNum)
+    override fun pushAABB(num: Int) {
+        aabbs.push(num)
     }
 
     override fun popRot(): Rot {

--- a/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbDeserializer.kt
+++ b/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbDeserializer.kt
@@ -53,12 +53,12 @@ class PbDeserializer : JbDeserializer {
         listener = argObjectListener
     }
 
-    override fun setObjectListener(argListener: JbDeserializer.ObjectListener) {
-        listener = argListener
+    override fun setObjectListener(listener: JbDeserializer.ObjectListener) {
+        this.listener = listener
     }
 
-    override fun setUnsupportedListener(argListener: UnsupportedListener) {
-        unsupportedlistener = argListener
+    override fun setUnsupportedListener(listener: UnsupportedListener) {
+        this.unsupportedlistener = listener
     }
 
     private fun isIndependentJoint(argType: PbJointType): Boolean {
@@ -66,8 +66,8 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeWorld(argInput: InputStream): World {
-        val world = PbWorld.parseFrom(argInput)
+    override fun deserializeWorld(input: InputStream): World {
+        val world = PbWorld.parseFrom(input)
         return deserializeWorld(world)
     }
 
@@ -112,9 +112,9 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeBody(argWorld: World, argInput: InputStream): Body {
-        val body = PbBody.parseFrom(argInput)
-        return deserializeBody(argWorld, body)
+    override fun deserializeBody(world: World, input: InputStream): Body {
+        val body = PbBody.parseFrom(input)
+        return deserializeBody(world, body)
     }
 
     fun deserializeBody(argWorld: World, argBody: PbBody): Body {
@@ -159,9 +159,9 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeFixture(argBody: Body, argInput: InputStream): Fixture {
-        val fixture = PbFixture.parseFrom(argInput)
-        return deserializeFixture(argBody, fixture)
+    override fun deserializeFixture(body: Body, input: InputStream): Fixture {
+        val fixture = PbFixture.parseFrom(input)
+        return deserializeFixture(body, fixture)
     }
 
     fun deserializeFixture(argBody: Body, argFixture: PbFixture): Fixture {
@@ -182,8 +182,8 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeShape(argInput: InputStream): Shape {
-        val s = PbShape.parseFrom(argInput)
+    override fun deserializeShape(input: InputStream): Shape {
+        val s = PbShape.parseFrom(input)
         return deserializeShape(s)
     }
 
@@ -248,10 +248,10 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeJoint(argWorld: World, argInput: InputStream,
-                                  argBodyMap: Map<Int, Body>, jointMap: Map<Int, Joint>): Joint {
-        val joint = PbJoint.parseFrom(argInput)
-        return deserializeJoint(argWorld, joint, argBodyMap, jointMap)
+    override fun deserializeJoint(world: World, input: InputStream,
+                                  bodyMap: Map<Int, Body>, jointMap: Map<Int, Joint>): Joint {
+        val joint = PbJoint.parseFrom(input)
+        return deserializeJoint(world, joint, bodyMap, jointMap)
     }
 
     fun deserializeJoint(argWorld: World, joint: PbJoint,
@@ -390,7 +390,7 @@ class PbDeserializer : JbDeserializer {
                                 "Joints for constant volume joint must be distance joints")
                     }
                     def.addBodyAndJoint(argBodyMap[body]!!,
-                            djoint as DistanceJoint)
+                            djoint)
                 }
             }
             PbJointType.LINE -> {

--- a/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbSerializer.kt
+++ b/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbSerializer.kt
@@ -56,24 +56,24 @@ class PbSerializer : JbSerializer {
         signer = argSigner
     }
 
-    override fun setObjectSigner(argSigner: JbSerializer.ObjectSigner) {
-        signer = argSigner
+    override fun setObjectSigner(signer: JbSerializer.ObjectSigner) {
+        this.signer = signer
     }
 
-    override fun setUnsupportedListener(argListener: UnsupportedListener) {
-        listener = argListener
+    override fun setUnsupportedListener(listener: UnsupportedListener) {
+        this.listener = listener
     }
 
-    override fun serialize(argWorld: World): SerializationResult {
-        val world = serializeWorld(argWorld).build()
+    override fun serialize(world: World): SerializationResult {
+        val worldPb = serializeWorld(world).build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                world.writeTo(argOutputStream)
+                worldPb.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return world
+                return worldPb
             }
         }
     }
@@ -126,17 +126,17 @@ class PbSerializer : JbSerializer {
         return builder
     }
 
-    override fun serialize(argBody: Body): SerializationResult {
-        val builder = serializeBody(argBody)
-        val body = builder.build()
+    override fun serialize(body: Body): SerializationResult {
+        val builder = serializeBody(body)
+        val bodyPb = builder.build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                body.writeTo(argOutputStream)
+                bodyPb.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return body
+                return bodyPb
             }
         }
     }
@@ -182,16 +182,16 @@ class PbSerializer : JbSerializer {
         return builder
     }
 
-    override fun serialize(argFixture: Fixture): SerializationResult {
-        val fixture = serializeFixture(argFixture).build()
+    override fun serialize(fixture: Fixture): SerializationResult {
+        val fixturePb = serializeFixture(fixture).build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                fixture.writeTo(argOutputStream)
+                fixturePb.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return fixture
+                return fixturePb
             }
         }
     }
@@ -209,22 +209,22 @@ class PbSerializer : JbSerializer {
         builder.restitution = argFixture.restitution
         builder.sensor = argFixture.isSensor
         builder.setShape(serializeShape(argFixture.shape!!))
-        builder.setFilter(serializeFilter(argFixture.filter!!))
+        builder.setFilter(serializeFilter(argFixture.filter))
         return builder
     }
 
-    override fun serialize(argShape: Shape): SerializationResult {
-        val builder = serializeShape(argShape)
+    override fun serialize(shape: Shape): SerializationResult {
+        val builder = serializeShape(shape)
 // should we do lazy building?
-        val shape = builder.build()
+        val shapePb = builder.build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                shape.writeTo(argOutputStream)
+                shapePb.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return shape
+                return shapePb
             }
         }
     }
@@ -287,19 +287,19 @@ class PbSerializer : JbSerializer {
         return builder
     }
 
-    override fun serialize(argJoint: Joint, argBodyIndexMap: Map<Body, Int>,
-                           argJointIndexMap: Map<Joint, Int>): SerializationResult {
-        val builder = serializeJoint(argJoint, argBodyIndexMap,
-                argJointIndexMap)
-        val joint = builder.build()
+    override fun serialize(joint: Joint, bodyIndexMap: Map<Body, Int>,
+                           jointIndexMap: Map<Joint, Int>): SerializationResult {
+        val builder = serializeJoint(joint, bodyIndexMap,
+                jointIndexMap)
+        val jointPb = builder.build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                joint.writeTo(argOutputStream)
+                jointPb.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return joint
+                return jointPb
             }
         }
     }


### PR DESCRIPTION
This PR addresses remaining Kotlin compiler warnings and API inconsistencies in `kfizzix-library` and `kfizzix-serialization-kt`.

Changes:
- **`DefaultWorldPool.kt`**:
  - Renamed parameters (e.g., `argNum` -> `num`) to strictly match the `WorldPool` interface, preventing named argument issues.
  - Added `@Suppress("UNCHECKED_CAST")` to `newArray` methods in the internal stack implementations to resolve unchecked cast warnings when creating generic arrays.

- **`PbDeserializer.kt`**:
  - Renamed parameters in `deserialize*` methods (e.g., `argInput` -> `input`, `argWorld` -> `world`) to match the `JbDeserializer` interface.
  - Removed a redundant cast to `DistanceJoint`.

- **`PbSerializer.kt`**:
  - Renamed parameters in `serialize` methods to match the `JbSerializer` interface.
  - Removed an unnecessary non-null assertion (`!!`) on `fixture.filter`.

All changes were verified by running `./gradlew :kfizzix-library:compileKotlin :kfizzix-serialization-kt:compileKotlin` and ensuring a clean build with no relevant warnings. Tests were also executed.

---
*PR created automatically by Jules for task [8442976563976869238](https://jules.google.com/task/8442976563976869238) started by @HereLiesAz*