### PR TITLE
Fix build environment and Android lint errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 
 
 KPhysics/
+local.properties

--- a/kfizzix-android-showcase/src/main/res/xml/data_extraction_rules.xml
+++ b/kfizzix-android-showcase/src/main/res/xml/data_extraction_rules.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <include domain="user" path="."/>
-        <exclude domain="user" path="exclude"/>
+        <include domain="file" path="."/>
+        <exclude domain="file" path="exclude"/>
     </cloud-backup>
     <device-transfer>
-        <include domain="user" path="."/>
-        <exclude domain="user" path="exclude"/>
+        <include domain="file" path="."/>
+        <exclude domain="file" path="exclude"/>
     </device-transfer>
 </data-extraction-rules>

--- a/local.properties
+++ b/local.properties
@@ -1,1 +1,0 @@
-sdk.dir=/usr/lib/android-sdk


### PR DESCRIPTION
Fixes build environment issues by removing `local.properties` from version control and adding it to `.gitignore`. Also resolves an Android Lint error in `kfizzix-android-showcase` by correcting the invalid `domain="user"` attribute in `data_extraction_rules.xml`.

---
*PR created automatically by Jules for task [9896413646456927820](https://jules.google.com/task/9896413646456927820) started by @HereLiesAz*

## Summary by Sourcery

Update Android backup/transfer rules and ignore local build configuration from version control.

Bug Fixes:
- Correct data extraction rule domains in the Android showcase app to resolve lint errors.

Build:
- Stop tracking local.properties and add it to .gitignore to prevent committing local build configuration.