### PR TITLE
Fix build configuration and Android lint issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 
 
 KPhysics/
+local.properties

--- a/kfizzix-android-showcase/src/main/res/xml/data_extraction_rules.xml
+++ b/kfizzix-android-showcase/src/main/res/xml/data_extraction_rules.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <include domain="user" path="."/>
-        <exclude domain="user" path="exclude"/>
+        <include domain="file" path="."/>
+        <exclude domain="file" path="exclude"/>
     </cloud-backup>
     <device-transfer>
-        <include domain="user" path="."/>
-        <exclude domain="user" path="exclude"/>
+        <include domain="file" path="."/>
+        <exclude domain="file" path="exclude"/>
     </device-transfer>
 </data-extraction-rules>

--- a/local.properties
+++ b/local.properties
@@ -1,1 +1,0 @@
-sdk.dir=/usr/lib/android-sdk


### PR DESCRIPTION
This pull request addresses two critical issues preventing a clean build and causing lint errors:

1.  **Build Configuration Hygiene**: `local.properties` was previously committed to the repository, forcing a hardcoded Android SDK path (`/usr/lib/android-sdk`) on all developers and CI environments. This caused build failures when the SDK was located elsewhere (e.g., `/opt/android-sdk`). I have removed `local.properties` from git tracking and added it to `.gitignore`. I also updated the local instance to point to the correct SDK path for the current environment to ensure verification.

2.  **Android Lint Fix**: The `kfizzix-android-showcase` module's `data_extraction_rules.xml` used an invalid domain attribute `user`. I have updated it to `file` (a valid domain for file-based extraction rules), which resolves the lint error and ensures proper backup behavior.

Verified that the project builds successfully (`./gradlew assemble`) and core library tests pass (`./gradlew :kfizzix-library:test`).

---
*PR created automatically by Jules for task [17055972960467646519](https://jules.google.com/task/17055972960467646519) started by @HereLiesAz*

## Summary by Sourcery

Fix Android lint configuration and clean up repository-local build configuration files.

Bug Fixes:
- Correct Android backup and device transfer data extraction rules by using a valid domain value to resolve lint errors.

Build:
- Stop tracking the Android local.properties file and ignore it in version control to avoid hardcoded SDK path issues across environments.