### PR TITLE
Fix remaining Kotlin compiler warnings in Joints and ParticleSystem

### DIFF
--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WeldJoint.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WeldJoint.kt
@@ -99,23 +99,23 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L308-L311
      */
-    override fun getAnchorA(argOut: Vec2) {
-        bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA.getWorldPointToOut(localAnchorA, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L313-L316
      */
-    override fun getAnchorB(argOut: Vec2) {
-        bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L318-L322
      */
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
-        argOut.set(impulse.x, impulse.y)
-        argOut.mulLocal(invDt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(impulse.x, impulse.y)
+        out.mulLocal(invDt)
     }
 
     /**
@@ -129,14 +129,14 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L62-L167
      */
     override fun initVelocityConstraints(data: SolverData) {
-        indexA = bodyA!!.islandIndex
-        indexB = bodyB!!.islandIndex
-        localCenterA.set(bodyA!!.sweep.localCenter)
-        localCenterB.set(bodyB!!.sweep.localCenter)
-        invMassA = bodyA!!.invMass
-        invMassB = bodyB!!.invMass
-        invIA = bodyA!!.invI
-        invIB = bodyB!!.invI
+        indexA = bodyA.islandIndex
+        indexB = bodyB.islandIndex
+        localCenterA.set(bodyA.sweep.localCenter)
+        localCenterB.set(bodyB.sweep.localCenter)
+        invMassA = bodyA.invMass
+        invMassB = bodyB.invMass
+        invIA = bodyA.invI
+        invIB = bodyB.invI
         // Vec2 cA = data.positions[indexA].c;
         val aA = data.positions!![indexA].a
         val vA = data.velocities!![indexA].v
@@ -263,17 +263,17 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
             val Cdot2 = wB - wA
             val Cdot = pool.popVec3()
             Cdot.set(Cdot1.x, Cdot1.y, Cdot2)
-            val impulse = pool.popVec3()
-            Mat33.mulToOutUnsafe(mass, Cdot, impulse)
-            impulse.negateLocal()
-            this.impulse.addLocal(impulse)
-            P.set(impulse.x, impulse.y)
+            val impulseVec = pool.popVec3()
+            Mat33.mulToOutUnsafe(mass, Cdot, impulseVec)
+            impulseVec.negateLocal()
+            this.impulse.addLocal(impulseVec)
+            P.set(impulseVec.x, impulseVec.y)
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * (Vec2.cross(rA, P) + impulse.z)
+            wA -= iA * (Vec2.cross(rA, P) + impulseVec.z)
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * (Vec2.cross(rB, P) + impulse.z)
+            wB += iB * (Vec2.cross(rB, P) + impulseVec.z)
             pool.pushVec3(2)
         }
         // data.velocities[indexA].v.set(vA);

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
@@ -74,8 +74,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var maxMotorTorque: Float
         get() = _maxMotorTorque
         set(torque) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _maxMotorTorque = torque
         }
 
@@ -86,8 +86,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var motorSpeed: Float
         get() = _motorSpeed
         set(speed) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _motorSpeed = speed
         }
 
@@ -146,24 +146,24 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L446-L449
      */
-    override fun getAnchorA(argOut: Vec2) {
-        bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA.getWorldPointToOut(localAnchorA, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L451-L454
      */
-    override fun getAnchorB(argOut: Vec2) {
-        bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L456-L459
      */
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
+    override fun getReactionForce(invDt: Float, out: Vec2) {
         val temp = pool.popVec2()
         temp.set(ay).mulLocal(impulse)
-        argOut.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
+        out.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
         pool.pushVec2(1)
     }
 
@@ -178,8 +178,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L466-L478
      */
     fun getJointTranslation(): Float {
-        val b1 = bodyA!!
-        val b2 = bodyB!!
+        val b1 = bodyA
+        val b2 = bodyB
         val p1 = pool.popVec2()
         val p2 = pool.popVec2()
         val axis = pool.popVec2()
@@ -200,7 +200,7 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     }
 
     fun getJointSpeed(): Float {
-        return bodyA!!.angularVelocity - bodyB!!.angularVelocity
+        return bodyA.angularVelocity - bodyB.angularVelocity
     }
 
     /**
@@ -214,8 +214,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L561-L569
      */
     fun enableMotor(flag: Boolean) {
-        bodyA!!.isAwake = true
-        bodyB!!.isAwake = true
+        bodyA.isAwake = true
+        bodyB.isAwake = true
         enableMotor = flag
     }
 
@@ -228,14 +228,14 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L89-L235
      */
     override fun initVelocityConstraints(data: SolverData) {
-        indexA = bodyA!!.islandIndex
-        indexB = bodyB!!.islandIndex
-        localCenterA.set(bodyA!!.sweep.localCenter)
-        localCenterB.set(bodyB!!.sweep.localCenter)
-        invMassA = bodyA!!.invMass
-        invMassB = bodyB!!.invMass
-        invIA = bodyA!!.invI
-        invIB = bodyB!!.invI
+        indexA = bodyA.islandIndex
+        indexB = bodyB.islandIndex
+        localCenterA.set(bodyA.sweep.localCenter)
+        localCenterB.set(bodyB.sweep.localCenter)
+        invMassA = bodyA.invMass
+        invMassB = bodyB.invMass
+        invIA = bodyA.invI
+        invIB = bodyB.invI
         val mA = invMassA
         val mB = invMassB
         val iA = invIA
@@ -357,12 +357,12 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
         // Solve spring constraint
         run {
             val Cdot = Vec2.dot(ax, temp.set(vB).subLocal(vA)) + sBx * wB - sAx * wA
-            val impulse = -springMass * (Cdot + bias + gamma * springImpulse)
-            springImpulse = springImpulse + impulse
-            P.x = impulse * ax.x
-            P.y = impulse * ax.y
-            val LA = impulse * sAx
-            val LB = impulse * sBx
+            val impulseVec = -springMass * (Cdot + bias + gamma * springImpulse)
+            springImpulse = springImpulse + impulseVec
+            P.x = impulseVec * ax.x
+            P.y = impulseVec * ax.y
+            val LA = impulseVec * sAx
+            val LB = impulseVec * sBx
             vA.x -= mA * P.x
             vA.y -= mA * P.y
             wA -= iA * LA
@@ -373,10 +373,10 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
         // Solve rotational motor constraint
         run {
             val Cdot = wB - wA - motorSpeed
-            val impulse = -motorMass * Cdot
+            val impulseVec = -motorMass * Cdot
             val oldImpulse = motorImpulse
             val maxImpulse = data.step!!.dt * maxMotorTorque
-            motorImpulse = MathUtils.clamp(motorImpulse + impulse, -maxImpulse, maxImpulse)
+            motorImpulse = MathUtils.clamp(motorImpulse + impulseVec, -maxImpulse, maxImpulse)
             val incImpulse = motorImpulse - oldImpulse
             wA -= iA * incImpulse
             wB += iB * incImpulse
@@ -384,12 +384,12 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
         // Solve point to line constraint
         run {
             val Cdot = Vec2.dot(ay, temp.set(vB).subLocal(vA)) + sBy * wB - sAy * wA
-            val impulse = -mass * Cdot
-            this.impulse = this.impulse + impulse
-            P.x = impulse * ay.x
-            P.y = impulse * ay.y
-            val LA = impulse * sAy
-            val LB = impulse * sBy
+            val impulseVec = -mass * Cdot
+            this.impulse = this.impulse + impulseVec
+            P.x = impulseVec * ay.x
+            P.y = impulseVec * ay.y
+            val LA = impulseVec * sAy
+            val LB = impulseVec * sBy
             vA.x -= mA * P.x
             vA.y -= mA * P.y
             wA -= iA * LA

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
@@ -172,7 +172,7 @@ class ParticleSystem(var world: World) {
     }
 
     private val capacity: Int
-        private get() {
+        get() {
             var capacity = if (count != 0) 2 * count else Settings.minParticleBufferCapacity
             capacity = limitCapacity(capacity, maxCount)
             capacity = limitCapacity(capacity, flagsBuffer.userSuppliedCapacity)
@@ -782,7 +782,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3260-L3304
      */
-    fun solveDamping(step: TimeStep) {
+    fun solveDamping(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // reduces the normal velocity of each contact
         val damping = dampingStrength
         for (k in 0 until bodyContactCount) {
@@ -836,7 +836,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3506-L3515
      */
-    fun solveWall(step: TimeStep) {
+    fun solveWall(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         for (i in 0 until count) {
             if (flagsBuffer.data!![i] and ParticleType.wallParticle != 0) {
                 val r = velocityBuffer.data!![i]!!
@@ -1019,7 +1019,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3660-L3694
      */
-    fun solveViscous(step: TimeStep) {
+    fun solveViscous(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         val viscousStrength = viscousStrength
         for (k in 0 until bodyContactCount) {
             val contact = bodyContactBuffer!![k]
@@ -1146,7 +1146,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3774-L3796
      */
-    fun solveColorMixing(step: TimeStep) {
+    fun solveColorMixing(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // mixes color between contacting particles
         colorBuffer.data = requestParticleBuffer(
             ParticleColor::class.java,
@@ -1330,8 +1330,8 @@ class ParticleSystem(var world: World) {
             var firstIndex = newCount
             var lastIndex = 0
             var modified = false
-            for (i in group.firstIndex until group.lastIndex) {
-                j = newIndices[i]
+            for (pIndex in group.firstIndex until group.lastIndex) {
+                j = newIndices[pIndex]
                 if (j >= 0) {
                     firstIndex = MathUtils.min(firstIndex, j)
                     lastIndex = MathUtils.max(lastIndex, j + 1)
@@ -1531,19 +1531,19 @@ class ParticleSystem(var world: World) {
         setParticleBuffer(userDataBuffer, buffer, capacity)
     }
 
-    private fun requestParticleBuffer(buffer: FloatArray?): FloatArray {
-        var buffer = buffer
+    private fun requestParticleBuffer(bufferIn: FloatArray?): FloatArray {
+        var buffer = bufferIn
         if (buffer == null) {
             buffer = FloatArray(internalAllocatedCapacity)
         }
         return buffer
     }
 
-    fun <T> requestParticleBuffer(clazz: Class<T>, buffer: Array<T?>?): Array<T?>? {
-        if (buffer == null) {
+    fun <T> requestParticleBuffer(clazz: Class<T>, bufferIn: Array<T?>?): Array<T?>? {
+        if (bufferIn == null) {
             return BufferUtils.reallocateBuffer(clazz, null, 0, internalAllocatedCapacity)
         }
-        return buffer
+        return bufferIn
     }
 
     class ParticleBuffer<T>(val dataClass: Class<T>) {


### PR DESCRIPTION
This PR addresses remaining Kotlin compiler warnings in the `kfizzix-library` module.

Changes:
- **WeldJoint.kt & WheelJoint.kt**:
    - Renamed local `impulse` variables to prevent shadowing class properties.
    - Renamed overridden method parameters (`argOut` -> `out`) to match `Joint` base class signature.
    - Removed redundant non-null assertions (`!!`) on `bodyA` and `bodyB`.
- **ParticleSystem.kt**:
    - Suppressed `UNUSED_PARAMETER` warnings for `step` in methods where it's required by signature but not used.
    - Fixed variable shadowing for `buffer` and loop variable `i`.
    - Removed redundant `private` visibility modifier on `capacity` getter.

These changes ensure a cleaner build log and stricter adherence to Kotlin coding standards.

---
*PR created automatically by Jules for task [18323635308800538088](https://jules.google.com/task/18323635308800538088) started by @HereLiesAz*