### PR TITLE
Fix Kotlin compiler warnings and API inconsistencies

### DIFF
--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
@@ -74,8 +74,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var maxMotorTorque: Float
         get() = _maxMotorTorque
         set(torque) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _maxMotorTorque = torque
         }
 
@@ -86,8 +86,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var motorSpeed: Float
         get() = _motorSpeed
         set(speed) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _motorSpeed = speed
         }
 
@@ -146,24 +146,24 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L446-L449
      */
-    override fun getAnchorA(argOut: Vec2) {
-        bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA.getWorldPointToOut(localAnchorA, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L451-L454
      */
-    override fun getAnchorB(argOut: Vec2) {
-        bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L456-L459
      */
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
+    override fun getReactionForce(invDt: Float, out: Vec2) {
         val temp = pool.popVec2()
         temp.set(ay).mulLocal(impulse)
-        argOut.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
+        out.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
         pool.pushVec2(1)
     }
 
@@ -178,8 +178,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L466-L478
      */
     fun getJointTranslation(): Float {
-        val b1 = bodyA!!
-        val b2 = bodyB!!
+        val b1 = bodyA
+        val b2 = bodyB
         val p1 = pool.popVec2()
         val p2 = pool.popVec2()
         val axis = pool.popVec2()
@@ -200,7 +200,7 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     }
 
     fun getJointSpeed(): Float {
-        return bodyA!!.angularVelocity - bodyB!!.angularVelocity
+        return bodyA.angularVelocity - bodyB.angularVelocity
     }
 
     /**
@@ -214,8 +214,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L561-L569
      */
     fun enableMotor(flag: Boolean) {
-        bodyA!!.isAwake = true
-        bodyB!!.isAwake = true
+        bodyA.isAwake = true
+        bodyB.isAwake = true
         enableMotor = flag
     }
 
@@ -228,14 +228,14 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L89-L235
      */
     override fun initVelocityConstraints(data: SolverData) {
-        indexA = bodyA!!.islandIndex
-        indexB = bodyB!!.islandIndex
-        localCenterA.set(bodyA!!.sweep.localCenter)
-        localCenterB.set(bodyB!!.sweep.localCenter)
-        invMassA = bodyA!!.invMass
-        invMassB = bodyB!!.invMass
-        invIA = bodyA!!.invI
-        invIB = bodyB!!.invI
+        indexA = bodyA.islandIndex
+        indexB = bodyB.islandIndex
+        localCenterA.set(bodyA.sweep.localCenter)
+        localCenterB.set(bodyB.sweep.localCenter)
+        invMassA = bodyA.invMass
+        invMassB = bodyB.invMass
+        invIA = bodyA.invI
+        invIB = bodyB.invI
         val mA = invMassA
         val mB = invMassB
         val iA = invIA

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
@@ -172,7 +172,7 @@ class ParticleSystem(var world: World) {
     }
 
     private val capacity: Int
-        private get() {
+        get() {
             var capacity = if (count != 0) 2 * count else Settings.minParticleBufferCapacity
             capacity = limitCapacity(capacity, maxCount)
             capacity = limitCapacity(capacity, flagsBuffer.userSuppliedCapacity)
@@ -782,7 +782,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3260-L3304
      */
-    fun solveDamping(step: TimeStep) {
+    fun solveDamping(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // reduces the normal velocity of each contact
         val damping = dampingStrength
         for (k in 0 until bodyContactCount) {
@@ -836,7 +836,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3506-L3515
      */
-    fun solveWall(step: TimeStep) {
+    fun solveWall(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         for (i in 0 until count) {
             if (flagsBuffer.data!![i] and ParticleType.wallParticle != 0) {
                 val r = velocityBuffer.data!![i]!!
@@ -1019,7 +1019,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3660-L3694
      */
-    fun solveViscous(step: TimeStep) {
+    fun solveViscous(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         val viscousStrength = viscousStrength
         for (k in 0 until bodyContactCount) {
             val contact = bodyContactBuffer!![k]
@@ -1146,7 +1146,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3774-L3796
      */
-    fun solveColorMixing(step: TimeStep) {
+    fun solveColorMixing(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // mixes color between contacting particles
         colorBuffer.data = requestParticleBuffer(
             ParticleColor::class.java,
@@ -1330,8 +1330,8 @@ class ParticleSystem(var world: World) {
             var firstIndex = newCount
             var lastIndex = 0
             var modified = false
-            for (i in group.firstIndex until group.lastIndex) {
-                j = newIndices[i]
+            for (k in group.firstIndex until group.lastIndex) {
+                j = newIndices[k]
                 if (j >= 0) {
                     firstIndex = MathUtils.min(firstIndex, j)
                     lastIndex = MathUtils.max(lastIndex, j + 1)
@@ -1531,8 +1531,8 @@ class ParticleSystem(var world: World) {
         setParticleBuffer(userDataBuffer, buffer, capacity)
     }
 
-    private fun requestParticleBuffer(buffer: FloatArray?): FloatArray {
-        var buffer = buffer
+    private fun requestParticleBuffer(argBuffer: FloatArray?): FloatArray {
+        var buffer = argBuffer
         if (buffer == null) {
             buffer = FloatArray(internalAllocatedCapacity)
         }
@@ -1666,7 +1666,10 @@ class ParticleSystem(var world: World) {
      * Callback used with VoronoiDiagram.
      */
     class CreateParticleGroupCallback : VoronoiDiagramCallback {
-        override fun callback(a: Int, b: Int, c: Int) {
+        override fun callback(aTag: Int, bTag: Int, cTag: Int) {
+            val a = aTag
+            val b = bTag
+            val c = cTag
             val pa = system!!.positionBuffer.data!![a]!!
             val pb = system!!.positionBuffer.data!![b]!!
             val pc = system!!.positionBuffer.data!![c]!!
@@ -1718,7 +1721,10 @@ class ParticleSystem(var world: World) {
 
     // Callback used with VoronoiDiagram.
     class JoinParticleGroupsCallback : VoronoiDiagramCallback {
-        override fun callback(a: Int, b: Int, c: Int) {
+        override fun callback(aTag: Int, bTag: Int, cTag: Int) {
+            val a = aTag
+            val b = bTag
+            val c = cTag
             // Create a triad if it will contain particles from both groups.
             val countA = ((if (a < groupB!!.firstIndex) 1 else 0)
                     + (if (b < groupB!!.firstIndex) 1 else 0)
@@ -2031,9 +2037,9 @@ class ParticleSystem(var world: World) {
             )
         }
 
-        private fun lowerBound(ray: Array<Proxy?>?, length: Int, tag: Long): Int {
+        private fun lowerBound(ray: Array<Proxy?>?, argLength: Int, tag: Long): Int {
             var left = 0
-            var length = length
+            var length = argLength
             var step: Int
             var curr: Int
             while (length > 0) {
@@ -2049,9 +2055,9 @@ class ParticleSystem(var world: World) {
             return left
         }
 
-        private fun upperBound(ray: Array<Proxy?>?, length: Int, tag: Long): Int {
+        private fun upperBound(ray: Array<Proxy?>?, argLength: Int, tag: Long): Int {
             var left = 0
-            var length = length
+            var length = argLength
             var step: Int
             var curr: Int
             while (length > 0) {
@@ -2068,13 +2074,13 @@ class ParticleSystem(var world: World) {
         }
 
         fun setParticleBuffer(buffer: ParticleBufferInt, newData: IntArray?, newCapacity: Int) {
-            assert(newData != null && newCapacity >= newData!!.size)
+            assert(newData != null && newCapacity >= newData.size)
             buffer.data = newData
             buffer.userSuppliedCapacity = newCapacity
         }
 
         fun <T> setParticleBuffer(buffer: ParticleBuffer<T>, newData: Array<T?>?, newCapacity: Int) {
-            assert(newData != null && newCapacity >= newData!!.size)
+            assert(newData != null && newCapacity >= newData.size)
             buffer.data = newData
             buffer.userSuppliedCapacity = newCapacity
         }
@@ -2137,11 +2143,11 @@ class ParticleSystem(var world: World) {
         }
     }
 
-    fun raycast(callback: ParticleRaycastCallback, point1: Vec2, point2: Vec2) {
+    fun raycast(@Suppress("UNUSED_PARAMETER") callback: ParticleRaycastCallback, @Suppress("UNUSED_PARAMETER") point1: Vec2, @Suppress("UNUSED_PARAMETER") point2: Vec2) {
         // Simple check
-        val p = tempVec
+        // val p = tempVec
         for (i in 0 until count) {
-            val pos = positionBuffer.data!![i]!!
+            // val pos = positionBuffer.data!![i]!!
             // Check distance to segment?
             // Stub: do nothing or iterate all
         }

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/VoronoiDiagram.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/VoronoiDiagram.kt
@@ -179,7 +179,7 @@ class VoronoiDiagram(generatorCapacity: Int) {
                 0,
                 MathUtils.min(g.center.y.toInt(), countY - 1)
             )
-            queue.push(taskPool.pop()!!.set(x, y, x + y * countX, g))
+            queue.push(taskPool.pop().set(x, y, x + y * countX, g))
         }
         while (!queue.empty()) {
             val front = queue.pop()
@@ -190,16 +190,16 @@ class VoronoiDiagram(generatorCapacity: Int) {
             if (diagram!![i] == null) {
                 diagram!![i] = g
                 if (x > 0) {
-                    queue.push(taskPool.pop()!!.set(x - 1, y, i - 1, g))
+                    queue.push(taskPool.pop().set(x - 1, y, i - 1, g))
                 }
                 if (y > 0) {
-                    queue.push(taskPool.pop()!!.set(x, y - 1, i - countX, g))
+                    queue.push(taskPool.pop().set(x, y - 1, i - countX, g))
                 }
                 if (x < countX - 1) {
-                    queue.push(taskPool.pop()!!.set(x + 1, y, i + 1, g))
+                    queue.push(taskPool.pop().set(x + 1, y, i + 1, g))
                 }
                 if (y < countY - 1) {
-                    queue.push(taskPool.pop()!!.set(x, y + 1, i + countX, g))
+                    queue.push(taskPool.pop().set(x, y + 1, i + countX, g))
                 }
             }
             taskPool.push(front)
@@ -212,8 +212,8 @@ class VoronoiDiagram(generatorCapacity: Int) {
                     val a = diagram!![i]
                     val b = diagram!![i + 1]
                     if (a !== b) {
-                        queue.push(taskPool.pop()!!.set(x, y, i, b))
-                        queue.push(taskPool.pop()!!.set(x + 1, y, i + 1, a))
+                        queue.push(taskPool.pop().set(x, y, i, b))
+                        queue.push(taskPool.pop().set(x + 1, y, i + 1, a))
                     }
                 }
             }
@@ -223,8 +223,8 @@ class VoronoiDiagram(generatorCapacity: Int) {
                     val a = diagram!![i]
                     val b = diagram!![i + countX]
                     if (a !== b) {
-                        queue.push(taskPool.pop()!!.set(x, y, i, b))
-                        queue.push(taskPool.pop()!!.set(x, y + 1, i + countX, a))
+                        queue.push(taskPool.pop().set(x, y, i, b))
+                        queue.push(taskPool.pop().set(x, y + 1, i + countX, a))
                     }
                 }
             }
@@ -246,16 +246,16 @@ class VoronoiDiagram(generatorCapacity: Int) {
                     if (a2 > b2) {
                         diagram!![i] = k
                         if (x > 0) {
-                            queue.push(taskPool.pop()!!.set(x - 1, y, i - 1, k))
+                            queue.push(taskPool.pop().set(x - 1, y, i - 1, k))
                         }
                         if (y > 0) {
-                            queue.push(taskPool.pop()!!.set(x, y - 1, i - countX, k))
+                            queue.push(taskPool.pop().set(x, y - 1, i - countX, k))
                         }
                         if (x < countX - 1) {
-                            queue.push(taskPool.pop()!!.set(x + 1, y, i + 1, k))
+                            queue.push(taskPool.pop().set(x + 1, y, i + 1, k))
                         }
                         if (y < countY - 1) {
-                            queue.push(taskPool.pop()!!.set(x, y + 1, i + countX, k))
+                            queue.push(taskPool.pop().set(x, y + 1, i + countX, k))
                         }
                         updated = true
                     }

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/pooling/normal/DefaultWorldPool.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/pooling/normal/DefaultWorldPool.kt
@@ -70,6 +70,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return PolygonContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -79,6 +80,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return CircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -88,6 +90,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return PolygonAndCircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -97,6 +100,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return EdgeAndCircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -106,6 +110,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return EdgeAndPolygonContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -115,6 +120,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return ChainAndCircleContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -124,6 +130,7 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
             return ChainAndPolygonContact(world)
         }
         override fun newArray(size: Int): Array<Contact> {
+            @Suppress("UNCHECKED_CAST")
             return arrayOfNulls<Contact>(size) as Array<Contact>
         }
     }
@@ -203,56 +210,56 @@ class DefaultWorldPool(argSize: Int, argContainerSize: Int) : WorldPool {
         return vecs.pop()
     }
 
-    override fun popVec2(argNum: Int): Array<Vec2> {
-        return vecs.pop(argNum)
+    override fun popVec2(num: Int): Array<Vec2> {
+        return vecs.pop(num)
     }
 
-    override fun pushVec2(argNum: Int) {
-        vecs.push(argNum)
+    override fun pushVec2(num: Int) {
+        vecs.push(num)
     }
 
     override fun popVec3(): Vec3 {
         return vec3s.pop()
     }
 
-    override fun popVec3(argNum: Int): Array<Vec3> {
-        return vec3s.pop(argNum)
+    override fun popVec3(num: Int): Array<Vec3> {
+        return vec3s.pop(num)
     }
 
-    override fun pushVec3(argNum: Int) {
-        vec3s.push(argNum)
+    override fun pushVec3(num: Int) {
+        vec3s.push(num)
     }
 
     override fun popMat22(): Mat22 {
         return mats.pop()
     }
 
-    override fun popMat22(argNum: Int): Array<Mat22> {
-        return mats.pop(argNum)
+    override fun popMat22(num: Int): Array<Mat22> {
+        return mats.pop(num)
     }
 
-    override fun pushMat22(argNum: Int) {
-        mats.push(argNum)
+    override fun pushMat22(num: Int) {
+        mats.push(num)
     }
 
     override fun popMat33(): Mat33 {
         return mat33s.pop()
     }
 
-    override fun pushMat33(argNum: Int) {
-        mat33s.push(argNum)
+    override fun pushMat33(num: Int) {
+        mat33s.push(num)
     }
 
     override fun popAABB(): AABB {
         return aabbs.pop()
     }
 
-    override fun popAABB(argNum: Int): Array<AABB> {
-        return aabbs.pop(argNum)
+    override fun popAABB(num: Int): Array<AABB> {
+        return aabbs.pop(num)
     }
 
-    override fun pushAABB(argNum: Int) {
-        aabbs.push(argNum)
+    override fun pushAABB(num: Int) {
+        aabbs.push(num)
     }
 
     override fun popRot(): Rot {

--- a/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbDeserializer.kt
+++ b/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbDeserializer.kt
@@ -53,12 +53,12 @@ class PbDeserializer : JbDeserializer {
         listener = argObjectListener
     }
 
-    override fun setObjectListener(argListener: JbDeserializer.ObjectListener) {
-        listener = argListener
+    override fun setObjectListener(listener: JbDeserializer.ObjectListener) {
+        this.listener = listener
     }
 
-    override fun setUnsupportedListener(argListener: UnsupportedListener) {
-        unsupportedlistener = argListener
+    override fun setUnsupportedListener(listener: UnsupportedListener) {
+        unsupportedlistener = listener
     }
 
     private fun isIndependentJoint(argType: PbJointType): Boolean {
@@ -66,8 +66,8 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeWorld(argInput: InputStream): World {
-        val world = PbWorld.parseFrom(argInput)
+    override fun deserializeWorld(input: InputStream): World {
+        val world = PbWorld.parseFrom(input)
         return deserializeWorld(world)
     }
 
@@ -112,9 +112,9 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeBody(argWorld: World, argInput: InputStream): Body {
-        val body = PbBody.parseFrom(argInput)
-        return deserializeBody(argWorld, body)
+    override fun deserializeBody(world: World, input: InputStream): Body {
+        val body = PbBody.parseFrom(input)
+        return deserializeBody(world, body)
     }
 
     fun deserializeBody(argWorld: World, argBody: PbBody): Body {
@@ -159,9 +159,9 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeFixture(argBody: Body, argInput: InputStream): Fixture {
-        val fixture = PbFixture.parseFrom(argInput)
-        return deserializeFixture(argBody, fixture)
+    override fun deserializeFixture(body: Body, input: InputStream): Fixture {
+        val fixture = PbFixture.parseFrom(input)
+        return deserializeFixture(body, fixture)
     }
 
     fun deserializeFixture(argBody: Body, argFixture: PbFixture): Fixture {
@@ -182,8 +182,8 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeShape(argInput: InputStream): Shape {
-        val s = PbShape.parseFrom(argInput)
+    override fun deserializeShape(input: InputStream): Shape {
+        val s = PbShape.parseFrom(input)
         return deserializeShape(s)
     }
 
@@ -248,10 +248,10 @@ class PbDeserializer : JbDeserializer {
     }
 
     @Throws(IOException::class)
-    override fun deserializeJoint(argWorld: World, argInput: InputStream,
-                                  argBodyMap: Map<Int, Body>, jointMap: Map<Int, Joint>): Joint {
-        val joint = PbJoint.parseFrom(argInput)
-        return deserializeJoint(argWorld, joint, argBodyMap, jointMap)
+    override fun deserializeJoint(world: World, input: InputStream,
+                                  bodyMap: Map<Int, Body>, jointMap: Map<Int, Joint>): Joint {
+        val joint = PbJoint.parseFrom(input)
+        return deserializeJoint(world, joint, bodyMap, jointMap)
     }
 
     fun deserializeJoint(argWorld: World, joint: PbJoint,
@@ -390,7 +390,7 @@ class PbDeserializer : JbDeserializer {
                                 "Joints for constant volume joint must be distance joints")
                     }
                     def.addBodyAndJoint(argBodyMap[body]!!,
-                            djoint as DistanceJoint)
+                            djoint)
                 }
             }
             PbJointType.LINE -> {

--- a/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbSerializer.kt
+++ b/kfizzix-serialization-kt/src/main/kotlin/com/hereliesaz/kfizzix/serialization/pb/PbSerializer.kt
@@ -56,24 +56,24 @@ class PbSerializer : JbSerializer {
         signer = argSigner
     }
 
-    override fun setObjectSigner(argSigner: JbSerializer.ObjectSigner) {
-        signer = argSigner
+    override fun setObjectSigner(signer: JbSerializer.ObjectSigner) {
+        this.signer = signer
     }
 
-    override fun setUnsupportedListener(argListener: UnsupportedListener) {
-        listener = argListener
+    override fun setUnsupportedListener(listener: UnsupportedListener) {
+        this.listener = listener
     }
 
-    override fun serialize(argWorld: World): SerializationResult {
-        val world = serializeWorld(argWorld).build()
+    override fun serialize(world: World): SerializationResult {
+        val pbWorld = serializeWorld(world).build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                world.writeTo(argOutputStream)
+                pbWorld.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return world
+                return pbWorld
             }
         }
     }
@@ -126,17 +126,17 @@ class PbSerializer : JbSerializer {
         return builder
     }
 
-    override fun serialize(argBody: Body): SerializationResult {
-        val builder = serializeBody(argBody)
-        val body = builder.build()
+    override fun serialize(body: Body): SerializationResult {
+        val builder = serializeBody(body)
+        val pbBody = builder.build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                body.writeTo(argOutputStream)
+                pbBody.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return body
+                return pbBody
             }
         }
     }
@@ -182,16 +182,16 @@ class PbSerializer : JbSerializer {
         return builder
     }
 
-    override fun serialize(argFixture: Fixture): SerializationResult {
-        val fixture = serializeFixture(argFixture).build()
+    override fun serialize(fixture: Fixture): SerializationResult {
+        val pbFixture = serializeFixture(fixture).build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                fixture.writeTo(argOutputStream)
+                pbFixture.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return fixture
+                return pbFixture
             }
         }
     }
@@ -209,22 +209,22 @@ class PbSerializer : JbSerializer {
         builder.restitution = argFixture.restitution
         builder.sensor = argFixture.isSensor
         builder.setShape(serializeShape(argFixture.shape!!))
-        builder.setFilter(serializeFilter(argFixture.filter!!))
+        builder.setFilter(serializeFilter(argFixture.filter))
         return builder
     }
 
-    override fun serialize(argShape: Shape): SerializationResult {
-        val builder = serializeShape(argShape)
+    override fun serialize(shape: Shape): SerializationResult {
+        val builder = serializeShape(shape)
 // should we do lazy building?
-        val shape = builder.build()
+        val pbShape = builder.build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                shape.writeTo(argOutputStream)
+                pbShape.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return shape
+                return pbShape
             }
         }
     }
@@ -287,19 +287,19 @@ class PbSerializer : JbSerializer {
         return builder
     }
 
-    override fun serialize(argJoint: Joint, argBodyIndexMap: Map<Body, Int>,
-                           argJointIndexMap: Map<Joint, Int>): SerializationResult {
-        val builder = serializeJoint(argJoint, argBodyIndexMap,
-                argJointIndexMap)
-        val joint = builder.build()
+    override fun serialize(joint: Joint, bodyIndexMap: Map<Body, Int>,
+                           jointIndexMap: Map<Joint, Int>): SerializationResult {
+        val builder = serializeJoint(joint, bodyIndexMap,
+                jointIndexMap)
+        val pbJoint = builder.build()
         return object : SerializationResult {
             @Throws(IOException::class)
             override fun writeTo(argOutputStream: OutputStream) {
-                joint.writeTo(argOutputStream)
+                pbJoint.writeTo(argOutputStream)
             }
 
             override fun getValue(): Any {
-                return joint
+                return pbJoint
             }
         }
     }


### PR DESCRIPTION
This PR addresses various Kotlin compiler warnings and API inconsistencies across the `kfizzix-library` and `kfizzix-serialization-kt` modules.

Changes include:
- **Redundant Assertions:** Removed unnecessary non-null assertions (`!!`) in `WheelJoint.kt` and `ParticleSystem.kt`.
- **Unused Parameters:** Added `@Suppress("UNUSED_PARAMETER")` to methods in `ParticleSystem.kt` where parameters are required by the signature but unused.
- **Shadowing:** Renamed variables in `ParticleSystem.kt` to avoid shadowing.
- **Unchecked Casts:** Suppressed unchecked cast warnings in `DefaultWorldPool.kt` for generic array creation.
- **Parameter Naming:** Updated parameter names in `WheelJoint.kt`, `PbDeserializer.kt`, and `PbSerializer.kt` to match supertype definitions.
- **Sync:** Merged changes from `main` to include recent documentation updates.

---
*PR created automatically by Jules for task [4916755332716282460](https://jules.google.com/task/4916755332716282460) started by @HereLiesAz*