### PR TITLE
Fix compilation errors and warnings in core library

### DIFF
--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/common/Vec2.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/common/Vec2.kt
@@ -382,34 +382,6 @@ class Vec2(
         return x * v.x + y * v.y
     }
 
-
-    operator fun plus(v: Vec2) = add(v)
-    operator fun minus(v: Vec2) = sub(v)
-    operator fun times(a: Float) = mul(a)
-    operator fun unaryMinus() = negate()
-
-    override fun toString(): String {
-        return "($x,$y)"
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Vec2
-
-        if (x != other.x) return false
-        if (y != other.y) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = x.hashCode()
-        result = 31 * result + y.hashCode()
-        return result
-    }
-
     companion object {
         private const val serialVersionUID = 1L
 

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WeldJoint.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WeldJoint.kt
@@ -99,23 +99,23 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L308-L311
      */
-    override fun getAnchorA(argOut: Vec2) {
-        bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA.getWorldPointToOut(localAnchorA, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L313-L316
      */
-    override fun getAnchorB(argOut: Vec2) {
-        bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L318-L322
      */
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
-        argOut.set(impulse.x, impulse.y)
-        argOut.mulLocal(invDt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(impulse.x, impulse.y)
+        out.mulLocal(invDt)
     }
 
     /**
@@ -129,14 +129,14 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L62-L167
      */
     override fun initVelocityConstraints(data: SolverData) {
-        indexA = bodyA!!.islandIndex
-        indexB = bodyB!!.islandIndex
-        localCenterA.set(bodyA!!.sweep.localCenter)
-        localCenterB.set(bodyB!!.sweep.localCenter)
-        invMassA = bodyA!!.invMass
-        invMassB = bodyB!!.invMass
-        invIA = bodyA!!.invI
-        invIB = bodyB!!.invI
+        indexA = bodyA.islandIndex
+        indexB = bodyB.islandIndex
+        localCenterA.set(bodyA.sweep.localCenter)
+        localCenterB.set(bodyB.sweep.localCenter)
+        invMassA = bodyA.invMass
+        invMassB = bodyB.invMass
+        invIA = bodyA.invI
+        invIB = bodyB.invI
         // Vec2 cA = data.positions[indexA].c;
         val aA = data.positions!![indexA].a
         val vA = data.velocities!![indexA].v

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
@@ -74,8 +74,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var maxMotorTorque: Float
         get() = _maxMotorTorque
         set(torque) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _maxMotorTorque = torque
         }
 
@@ -86,8 +86,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var motorSpeed: Float
         get() = _motorSpeed
         set(speed) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _motorSpeed = speed
         }
 
@@ -146,24 +146,24 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L446-L449
      */
-    override fun getAnchorA(argOut: Vec2) {
-        bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA.getWorldPointToOut(localAnchorA, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L451-L454
      */
-    override fun getAnchorB(argOut: Vec2) {
-        bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L456-L459
      */
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
+    override fun getReactionForce(invDt: Float, out: Vec2) {
         val temp = pool.popVec2()
         temp.set(ay).mulLocal(impulse)
-        argOut.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
+        out.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
         pool.pushVec2(1)
     }
 
@@ -178,8 +178,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L466-L478
      */
     fun getJointTranslation(): Float {
-        val b1 = bodyA!!
-        val b2 = bodyB!!
+        val b1 = bodyA
+        val b2 = bodyB
         val p1 = pool.popVec2()
         val p2 = pool.popVec2()
         val axis = pool.popVec2()
@@ -200,7 +200,7 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     }
 
     fun getJointSpeed(): Float {
-        return bodyA!!.angularVelocity - bodyB!!.angularVelocity
+        return bodyA.angularVelocity - bodyB.angularVelocity
     }
 
     /**
@@ -214,8 +214,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L561-L569
      */
     fun enableMotor(flag: Boolean) {
-        bodyA!!.isAwake = true
-        bodyB!!.isAwake = true
+        bodyA.isAwake = true
+        bodyB.isAwake = true
         enableMotor = flag
     }
 
@@ -228,14 +228,14 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L89-L235
      */
     override fun initVelocityConstraints(data: SolverData) {
-        indexA = bodyA!!.islandIndex
-        indexB = bodyB!!.islandIndex
-        localCenterA.set(bodyA!!.sweep.localCenter)
-        localCenterB.set(bodyB!!.sweep.localCenter)
-        invMassA = bodyA!!.invMass
-        invMassB = bodyB!!.invMass
-        invIA = bodyA!!.invI
-        invIB = bodyB!!.invI
+        indexA = bodyA.islandIndex
+        indexB = bodyB.islandIndex
+        localCenterA.set(bodyA.sweep.localCenter)
+        localCenterB.set(bodyB.sweep.localCenter)
+        invMassA = bodyA.invMass
+        invMassB = bodyB.invMass
+        invIA = bodyA.invI
+        invIB = bodyB.invI
         val mA = invMassA
         val mB = invMassB
         val iA = invIA

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
@@ -172,7 +172,7 @@ class ParticleSystem(var world: World) {
     }
 
     private val capacity: Int
-        private get() {
+        get() {
             var capacity = if (count != 0) 2 * count else Settings.minParticleBufferCapacity
             capacity = limitCapacity(capacity, maxCount)
             capacity = limitCapacity(capacity, flagsBuffer.userSuppliedCapacity)
@@ -782,7 +782,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3260-L3304
      */
-    fun solveDamping(step: TimeStep) {
+    fun solveDamping(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // reduces the normal velocity of each contact
         val damping = dampingStrength
         for (k in 0 until bodyContactCount) {
@@ -836,7 +836,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3506-L3515
      */
-    fun solveWall(step: TimeStep) {
+    fun solveWall(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         for (i in 0 until count) {
             if (flagsBuffer.data!![i] and ParticleType.wallParticle != 0) {
                 val r = velocityBuffer.data!![i]!!
@@ -1019,7 +1019,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3660-L3694
      */
-    fun solveViscous(step: TimeStep) {
+    fun solveViscous(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         val viscousStrength = viscousStrength
         for (k in 0 until bodyContactCount) {
             val contact = bodyContactBuffer!![k]
@@ -1146,7 +1146,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3774-L3796
      */
-    fun solveColorMixing(step: TimeStep) {
+    fun solveColorMixing(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // mixes color between contacting particles
         colorBuffer.data = requestParticleBuffer(
             ParticleColor::class.java,
@@ -1330,8 +1330,8 @@ class ParticleSystem(var world: World) {
             var firstIndex = newCount
             var lastIndex = 0
             var modified = false
-            for (i in group.firstIndex until group.lastIndex) {
-                j = newIndices[i]
+            for (k in group.firstIndex until group.lastIndex) {
+                j = newIndices[k]
                 if (j >= 0) {
                     firstIndex = MathUtils.min(firstIndex, j)
                     lastIndex = MathUtils.max(lastIndex, j + 1)
@@ -1531,8 +1531,8 @@ class ParticleSystem(var world: World) {
         setParticleBuffer(userDataBuffer, buffer, capacity)
     }
 
-    private fun requestParticleBuffer(buffer: FloatArray?): FloatArray {
-        var buffer = buffer
+    private fun requestParticleBuffer(targetBuffer: FloatArray?): FloatArray {
+        var buffer = targetBuffer
         if (buffer == null) {
             buffer = FloatArray(internalAllocatedCapacity)
         }


### PR DESCRIPTION
Resolves conflicting overloads in `Vec2.kt` by removing duplicate method definitions. Fixes redundant assertions and parameter naming in `WeldJoint` and `WheelJoint`. Resolves shadowed variables and unused parameters in `ParticleSystem.kt`. Verified with `assemble` and `test`.

---
*PR created automatically by Jules for task [6281713041107963918](https://jules.google.com/task/6281713041107963918) started by @HereLiesAz*