### PR TITLE
Fix Kotlin compiler warnings and API inconsistencies

### DIFF
--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/common/Vec2.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/common/Vec2.kt
@@ -33,8 +33,8 @@ import java.io.Serializable
  * velocity, force, and impulses.
  *
  * **Performance Note:**
- * Many methods have a standard version (e.g., [add]) which creates a new [Vec2] object,
- * and a "Local" or "ToOut" version (e.g., [addLocal], [addToOut]) which modifies an existing object.
+ * Many methods have a standard version (e.g., [plus]) which creates a new [Vec2] object,
+ * and a "Local" or "ToOut" version (e.g., [addLocal]) which modifies an existing object.
  * In a physics engine, avoiding garbage collection (GC) is critical. Prefer using the "Local"
  * or "ToOut" methods in tight loops to reuse objects.
  *
@@ -155,10 +155,10 @@ class Vec2(
     }
 
     /**
-     * Adds two vectors and stores the result in this vector (mutation).
-     * this += v.
-     * @param v The vector to add.
-     * @return This vector (for chaining).
+     * Subtracts a vector from this one and returns a new vector.
+     * Result = this - v.
+     * @param v The vector to subtract.
+     * @return A new vector containing the difference.
      */
     operator fun minus(v: Vec2): Vec2 {
         // Create and return a new Vec2 where each component is the difference.
@@ -166,10 +166,10 @@ class Vec2(
     }
 
     /**
-     * Adds specific x and y values to this vector (mutation).
-     * @param x The x amount to add.
-     * @param y The y amount to add.
-     * @return This vector (for chaining).
+     * Multiplies this vector by a scalar and returns a new vector.
+     * Result = this * a.
+     * @param a The scalar to multiply by.
+     * @return A new vector containing the scaled result.
      */
     operator fun times(a: Float): Vec2 {
         // Create and return a new Vec2 where each component is scaled by 'a'.
@@ -177,10 +177,9 @@ class Vec2(
     }
 
     /**
-     * Subtracts a vector from this one and returns a new vector.
-     * Result = this - v.
-     * @param v The vector to subtract.
-     * @return A new vector containing the difference.
+     * Negates this vector and returns a new vector.
+     * Result = -this.
+     * @return A new vector with negated components.
      */
     operator fun unaryMinus(): Vec2 {
         // Create and return a new Vec2 with negated components.
@@ -188,9 +187,8 @@ class Vec2(
     }
 
     /**
-     * Subtracts a vector from this one and stores the result in this vector (mutation).
-     * this -= v.
-     * @param v The vector to subtract.
+     * Negates this vector in place (mutation).
+     * this = -this.
      * @return This vector (for chaining).
      */
     fun negateLocal(): Vec2 {
@@ -203,10 +201,10 @@ class Vec2(
     }
 
     /**
-     * Multiplies this vector by a scalar and returns a new vector.
-     * Result = this * a.
-     * @param a The scalar value.
-     * @return A new scaled vector.
+     * Adds another vector to this vector (mutation).
+     * this += v.
+     * @param v The vector to add.
+     * @return This vector (for chaining).
      */
     fun addLocal(v: Vec2): Vec2 {
         // Add the source vector's x to this vector's x.
@@ -218,9 +216,10 @@ class Vec2(
     }
 
     /**
-     * Multiplies this vector by a scalar and stores the result in this vector (mutation).
-     * this *= a.
-     * @param a The scalar value.
+     * Adds specified x and y values to this vector (mutation).
+     * this += (x, y).
+     * @param x The x value to add.
+     * @param y The y value to add.
      * @return This vector (for chaining).
      */
     fun addLocal(x: Float, y: Float): Vec2 {
@@ -233,9 +232,10 @@ class Vec2(
     }
 
     /**
-     * Negates this vector and returns a new vector.
-     * Result = -this.
-     * @return A new vector (-x, -y).
+     * Subtracts another vector from this vector (mutation).
+     * this -= v.
+     * @param v The vector to subtract.
+     * @return This vector (for chaining).
      */
     fun subLocal(v: Vec2): Vec2 {
         // Subtract the source vector's x from this vector's x.
@@ -247,8 +247,9 @@ class Vec2(
     }
 
     /**
-     * Negates this vector in place (mutation).
-     * this = -this.
+     * Multiplies this vector by a scalar (mutation).
+     * this *= a.
+     * @param a The scalar to multiply by.
      * @return This vector (for chaining).
      */
     fun mulLocal(a: Float): Vec2 {
@@ -360,12 +361,11 @@ class Vec2(
     }
 
     /**
-     * Calculates the dot product with another vector.
-     * Dot product = x1*x2 + y1*y2.
-     * Geometric meaning: |a||b|cos(theta).
-     * If dot > 0, angle is acute. If dot < 0, angle is obtuse. If dot == 0, vectors are perpendicular.
+     * Subtracts another vector from this one and returns a new vector.
+     * Result = this - v.
+     * Equivalent to [minus].
      * @param v The other vector.
-     * @return The scalar dot product.
+     * @return A new vector (this - v).
      */
     fun sub(v: Vec2): Vec2 {
         // Create and return a new vector representing (this - v).
@@ -380,34 +380,6 @@ class Vec2(
     fun dot(v: Vec2): Float {
         // The dot product is the sum of the products of corresponding components.
         return x * v.x + y * v.y
-    }
-
-
-    operator fun plus(v: Vec2) = add(v)
-    operator fun minus(v: Vec2) = sub(v)
-    operator fun times(a: Float) = mul(a)
-    operator fun unaryMinus() = negate()
-
-    override fun toString(): String {
-        return "($x,$y)"
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Vec2
-
-        if (x != other.x) return false
-        if (y != other.y) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = x.hashCode()
-        result = 31 * result + y.hashCode()
-        return result
     }
 
     companion object {

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WeldJoint.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WeldJoint.kt
@@ -99,23 +99,23 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L308-L311
      */
-    override fun getAnchorA(argOut: Vec2) {
-        bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA.getWorldPointToOut(localAnchorA, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L313-L316
      */
-    override fun getAnchorB(argOut: Vec2) {
-        bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L318-L322
      */
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
-        argOut.set(impulse.x, impulse.y)
-        argOut.mulLocal(invDt)
+    override fun getReactionForce(invDt: Float, out: Vec2) {
+        out.set(impulse.x, impulse.y)
+        out.mulLocal(invDt)
     }
 
     /**
@@ -129,14 +129,14 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_weld_joint.cpp#L62-L167
      */
     override fun initVelocityConstraints(data: SolverData) {
-        indexA = bodyA!!.islandIndex
-        indexB = bodyB!!.islandIndex
-        localCenterA.set(bodyA!!.sweep.localCenter)
-        localCenterB.set(bodyB!!.sweep.localCenter)
-        invMassA = bodyA!!.invMass
-        invMassB = bodyB!!.invMass
-        invIA = bodyA!!.invI
-        invIB = bodyB!!.invI
+        indexA = bodyA.islandIndex
+        indexB = bodyB.islandIndex
+        localCenterA.set(bodyA.sweep.localCenter)
+        localCenterB.set(bodyB.sweep.localCenter)
+        invMassA = bodyA.invMass
+        invMassB = bodyB.invMass
+        invIA = bodyA.invI
+        invIB = bodyB.invI
         // Vec2 cA = data.positions[indexA].c;
         val aA = data.positions!![indexA].a
         val vA = data.velocities!![indexA].v
@@ -263,17 +263,17 @@ class WeldJoint(argWorld: WorldPool, def: WeldJointDef) : Joint(argWorld, def) {
             val Cdot2 = wB - wA
             val Cdot = pool.popVec3()
             Cdot.set(Cdot1.x, Cdot1.y, Cdot2)
-            val impulse = pool.popVec3()
-            Mat33.mulToOutUnsafe(mass, Cdot, impulse)
-            impulse.negateLocal()
-            this.impulse.addLocal(impulse)
-            P.set(impulse.x, impulse.y)
+            val impulseVec = pool.popVec3()
+            Mat33.mulToOutUnsafe(mass, Cdot, impulseVec)
+            impulseVec.negateLocal()
+            this.impulse.addLocal(impulseVec)
+            P.set(impulseVec.x, impulseVec.y)
             vA.x -= mA * P.x
             vA.y -= mA * P.y
-            wA -= iA * (Vec2.cross(rA, P) + impulse.z)
+            wA -= iA * (Vec2.cross(rA, P) + impulseVec.z)
             vB.x += mB * P.x
             vB.y += mB * P.y
-            wB += iB * (Vec2.cross(rB, P) + impulse.z)
+            wB += iB * (Vec2.cross(rB, P) + impulseVec.z)
             pool.pushVec3(2)
         }
         // data.velocities[indexA].v.set(vA);

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/dynamics/joints/WheelJoint.kt
@@ -74,8 +74,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var maxMotorTorque: Float
         get() = _maxMotorTorque
         set(torque) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _maxMotorTorque = torque
         }
 
@@ -86,8 +86,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     var motorSpeed: Float
         get() = _motorSpeed
         set(speed) {
-            bodyA!!.isAwake = true
-            bodyB!!.isAwake = true
+            bodyA.isAwake = true
+            bodyB.isAwake = true
             _motorSpeed = speed
         }
 
@@ -146,24 +146,24 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L446-L449
      */
-    override fun getAnchorA(argOut: Vec2) {
-        bodyA!!.getWorldPointToOut(localAnchorA, argOut)
+    override fun getAnchorA(out: Vec2) {
+        bodyA.getWorldPointToOut(localAnchorA, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L451-L454
      */
-    override fun getAnchorB(argOut: Vec2) {
-        bodyB!!.getWorldPointToOut(localAnchorB, argOut)
+    override fun getAnchorB(out: Vec2) {
+        bodyB.getWorldPointToOut(localAnchorB, out)
     }
 
     /**
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L456-L459
      */
-    override fun getReactionForce(invDt: Float, argOut: Vec2) {
+    override fun getReactionForce(invDt: Float, out: Vec2) {
         val temp = pool.popVec2()
         temp.set(ay).mulLocal(impulse)
-        argOut.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
+        out.set(ax).mulLocal(springImpulse).addLocal(temp).mulLocal(invDt)
         pool.pushVec2(1)
     }
 
@@ -178,8 +178,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L466-L478
      */
     fun getJointTranslation(): Float {
-        val b1 = bodyA!!
-        val b2 = bodyB!!
+        val b1 = bodyA
+        val b2 = bodyB
         val p1 = pool.popVec2()
         val p2 = pool.popVec2()
         val axis = pool.popVec2()
@@ -200,7 +200,7 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
     }
 
     fun getJointSpeed(): Float {
-        return bodyA!!.angularVelocity - bodyB!!.angularVelocity
+        return bodyA.angularVelocity - bodyB.angularVelocity
     }
 
     /**
@@ -214,8 +214,8 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L561-L569
      */
     fun enableMotor(flag: Boolean) {
-        bodyA!!.isAwake = true
-        bodyB!!.isAwake = true
+        bodyA.isAwake = true
+        bodyB.isAwake = true
         enableMotor = flag
     }
 
@@ -228,14 +228,14 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
      * @repolink https://github.com/erincatto/box2d/blob/411acc32eb6d4f2e96fc70ddbdf01fe5f9b16230/src/dynamics/b2_wheel_joint.cpp#L89-L235
      */
     override fun initVelocityConstraints(data: SolverData) {
-        indexA = bodyA!!.islandIndex
-        indexB = bodyB!!.islandIndex
-        localCenterA.set(bodyA!!.sweep.localCenter)
-        localCenterB.set(bodyB!!.sweep.localCenter)
-        invMassA = bodyA!!.invMass
-        invMassB = bodyB!!.invMass
-        invIA = bodyA!!.invI
-        invIB = bodyB!!.invI
+        indexA = bodyA.islandIndex
+        indexB = bodyB.islandIndex
+        localCenterA.set(bodyA.sweep.localCenter)
+        localCenterB.set(bodyB.sweep.localCenter)
+        invMassA = bodyA.invMass
+        invMassB = bodyB.invMass
+        invIA = bodyA.invI
+        invIB = bodyB.invI
         val mA = invMassA
         val mB = invMassB
         val iA = invIA
@@ -357,12 +357,12 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
         // Solve spring constraint
         run {
             val Cdot = Vec2.dot(ax, temp.set(vB).subLocal(vA)) + sBx * wB - sAx * wA
-            val impulse = -springMass * (Cdot + bias + gamma * springImpulse)
-            springImpulse = springImpulse + impulse
-            P.x = impulse * ax.x
-            P.y = impulse * ax.y
-            val LA = impulse * sAx
-            val LB = impulse * sBx
+            val impulseInc = -springMass * (Cdot + bias + gamma * springImpulse)
+            springImpulse = springImpulse + impulseInc
+            P.x = impulseInc * ax.x
+            P.y = impulseInc * ax.y
+            val LA = impulseInc * sAx
+            val LB = impulseInc * sBx
             vA.x -= mA * P.x
             vA.y -= mA * P.y
             wA -= iA * LA
@@ -373,10 +373,10 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
         // Solve rotational motor constraint
         run {
             val Cdot = wB - wA - motorSpeed
-            val impulse = -motorMass * Cdot
+            val impulseInc = -motorMass * Cdot
             val oldImpulse = motorImpulse
             val maxImpulse = data.step!!.dt * maxMotorTorque
-            motorImpulse = MathUtils.clamp(motorImpulse + impulse, -maxImpulse, maxImpulse)
+            motorImpulse = MathUtils.clamp(motorImpulse + impulseInc, -maxImpulse, maxImpulse)
             val incImpulse = motorImpulse - oldImpulse
             wA -= iA * incImpulse
             wB += iB * incImpulse
@@ -384,12 +384,12 @@ class WheelJoint(argPool: WorldPool, def: WheelJointDef) : Joint(argPool, def) {
         // Solve point to line constraint
         run {
             val Cdot = Vec2.dot(ay, temp.set(vB).subLocal(vA)) + sBy * wB - sAy * wA
-            val impulse = -mass * Cdot
-            this.impulse = this.impulse + impulse
-            P.x = impulse * ay.x
-            P.y = impulse * ay.y
-            val LA = impulse * sAy
-            val LB = impulse * sBy
+            val impulseInc = -mass * Cdot
+            this.impulse = this.impulse + impulseInc
+            P.x = impulseInc * ay.x
+            P.y = impulseInc * ay.y
+            val LA = impulseInc * sAy
+            val LB = impulseInc * sBy
             vA.x -= mA * P.x
             vA.y -= mA * P.y
             wA -= iA * LA

--- a/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
+++ b/kfizzix-library/src/main/kotlin/com/hereliesaz/kfizzix/particle/ParticleSystem.kt
@@ -172,7 +172,7 @@ class ParticleSystem(var world: World) {
     }
 
     private val capacity: Int
-        private get() {
+        get() {
             var capacity = if (count != 0) 2 * count else Settings.minParticleBufferCapacity
             capacity = limitCapacity(capacity, maxCount)
             capacity = limitCapacity(capacity, flagsBuffer.userSuppliedCapacity)
@@ -782,7 +782,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3260-L3304
      */
-    fun solveDamping(step: TimeStep) {
+    fun solveDamping(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // reduces the normal velocity of each contact
         val damping = dampingStrength
         for (k in 0 until bodyContactCount) {
@@ -836,7 +836,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3506-L3515
      */
-    fun solveWall(step: TimeStep) {
+    fun solveWall(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         for (i in 0 until count) {
             if (flagsBuffer.data!![i] and ParticleType.wallParticle != 0) {
                 val r = velocityBuffer.data!![i]!!
@@ -1019,7 +1019,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3660-L3694
      */
-    fun solveViscous(step: TimeStep) {
+    fun solveViscous(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         val viscousStrength = viscousStrength
         for (k in 0 until bodyContactCount) {
             val contact = bodyContactBuffer!![k]
@@ -1146,7 +1146,7 @@ class ParticleSystem(var world: World) {
     /**
      * @repolink https://github.com/google/liquidfun/blob/7f20402173fd143a3988c921bc384459c6a858f2/liquidfun/Box2D/Box2D/Particle/b2ParticleSystem.cpp#L3774-L3796
      */
-    fun solveColorMixing(step: TimeStep) {
+    fun solveColorMixing(@Suppress("UNUSED_PARAMETER") step: TimeStep) {
         // mixes color between contacting particles
         colorBuffer.data = requestParticleBuffer(
             ParticleColor::class.java,
@@ -1330,8 +1330,8 @@ class ParticleSystem(var world: World) {
             var firstIndex = newCount
             var lastIndex = 0
             var modified = false
-            for (i in group.firstIndex until group.lastIndex) {
-                j = newIndices[i]
+            for (pIndex in group.firstIndex until group.lastIndex) {
+                j = newIndices[pIndex]
                 if (j >= 0) {
                     firstIndex = MathUtils.min(firstIndex, j)
                     lastIndex = MathUtils.max(lastIndex, j + 1)
@@ -1531,19 +1531,19 @@ class ParticleSystem(var world: World) {
         setParticleBuffer(userDataBuffer, buffer, capacity)
     }
 
-    private fun requestParticleBuffer(buffer: FloatArray?): FloatArray {
-        var buffer = buffer
+    private fun requestParticleBuffer(bufferIn: FloatArray?): FloatArray {
+        var buffer = bufferIn
         if (buffer == null) {
             buffer = FloatArray(internalAllocatedCapacity)
         }
         return buffer
     }
 
-    fun <T> requestParticleBuffer(clazz: Class<T>, buffer: Array<T?>?): Array<T?>? {
-        if (buffer == null) {
+    fun <T> requestParticleBuffer(clazz: Class<T>, bufferIn: Array<T?>?): Array<T?>? {
+        if (bufferIn == null) {
             return BufferUtils.reallocateBuffer(clazz, null, 0, internalAllocatedCapacity)
         }
-        return buffer
+        return bufferIn
     }
 
     class ParticleBuffer<T>(val dataClass: Class<T>) {


### PR DESCRIPTION
This PR addresses remaining Kotlin compiler warnings in `WeldJoint`, `WheelJoint`, and `ParticleSystem` by renaming shadowed variables, updating parameter names to match overrides, and removing redundant non-null assertions. It also cleans up `Vec2.kt` by removing duplicated methods and correcting KDoc. Verified with unit tests.

---
*PR created automatically by Jules for task [4540703083919362673](https://jules.google.com/task/4540703083919362673) started by @HereLiesAz*